### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ def versions = [
         gradlePitest       : '1.3.0',
         sonarPitest        : '0.5',
         junit5             : '5.7.2',
-        log4JVersion       : '2.16.0'
+        log4JVersion       : '2.17.0'
 ]
 sourceSets {
     aat {


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105