### PR TITLE
EM-4666 enable debug level logs

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -124,4 +124,5 @@ springdoc:
 
 logging:
   level:
+    uk.gov.hmcts: INFO
     uk.gov.hmcts.reform.authorisation.filters: DEBUG


### PR DESCRIPTION


### JIRA link (if applicable) ###

EM-4666 enable debug level logs
debug logs does not got to app-insight , 
after this PR I will change `ROOT_LOGGING_LEVEL`. to debug and this pr will prevent debug logs appear in pod,
