### PR TITLE
upgrading to cftlib v0.19.1262

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id 'checkstyle'
     id 'au.com.dius.pact' version '4.2.11'
     id "info.solidsoft.pitest" version '1.15.0'
-    id 'com.github.hmcts.rse-cft-lib' version '0.19.1260'
+    id 'com.github.hmcts.rse-cft-lib' version '0.19.1262'
     id "io.freefair.lombok" version "8.6"
 }
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/EM-6070

### Change description ###

Note - cftlib 0.19.1262 has a dependency within AM that requires java 17 within the toolchain to run properly.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
