### PR TITLE
EM-7210 Clean up build.gradle by removing comments and version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,9 +194,6 @@ processIntegrationTestResources {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
-//CVE-2026-41840, CVE-2026-41841, CVE-2026-41842, CVE-2026-41843, CVE-2026-41850, CVE-2026-41851
-ext['spring-framework.version'] = '6.2.19'
-
 dependencyManagement {
     dependencies {
 


### PR DESCRIPTION


### Jira link

[EM-7210
](https://tools.hmcts.net/jira/browse/EM-7210)Removed commented CVE references and spring-framework version as we moved to 'org.springframework.boot' version '3.5.15'